### PR TITLE
Fix configure option '--disable-silent-rules' not working

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,8 +11,8 @@ dnl
 AC_PREREQ(2.50)
 AC_CONFIG_AUX_DIR(.auto)
 AC_CANONICAL_SYSTEM
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_INIT_AUTOMAKE([subdir-objects no-define tar-ustar silent-rules])
-AM_DEFAULT_VERBOSITY=0
 
 AC_PROG_CXX
 AM_PROG_LIBTOOL


### PR DESCRIPTION
The user applied **configure** option `--disable-silent-rules` should disable default silent rules.