### PR TITLE
Fix sprite transparency to check for non-zero bits

### DIFF
--- a/src/pico8/gfx.cpp
+++ b/src/pico8/gfx.cpp
@@ -621,7 +621,7 @@ void vm::api_tline(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
         {
             int col = m_ram.gfx.get(sprite % 16 * 8 + (int(mx << 3) & 0x7),
                                     sprite / 16 * 8 + (int(my << 3) & 0x7));
-            if ((ds.draw_palette[col] & 0x10) == 0)
+            if ((ds.draw_palette[col] & 0xf0) == 0)
             {
                 uint32_t color_bits = (ds.draw_palette[col] & 0xf) << 16;
                 set_pixel(x, y, color_bits);
@@ -694,7 +694,7 @@ void vm::api_map(int16_t cel_x, int16_t cel_y, int16_t sx, int16_t sy,
         {
             int col = m_ram.gfx.get(sprite % 16 * 8 + (src_x + dx) % 8,
                                     sprite / 16 * 8 + (src_y + dy) % 8);
-            if ((ds.draw_palette[col] & 0x10) == 0)
+            if ((ds.draw_palette[col] & 0xf0) == 0)
             {
                 uint32_t color_bits = (ds.draw_palette[col] & 0xf) << 16;
                 set_pixel(sx + dx, sy + dy, color_bits);
@@ -957,7 +957,7 @@ void vm::api_spr(int16_t n, int16_t x, int16_t y, opt<fix32> w,
             int16_t di = flip_x ? w8 - 1 - i : i;
             int16_t dj = flip_y ? h8 - 1 - j : j;
             uint8_t col = m_ram.gfx.safe_get(n % 16 * 8 + di, n / 16 * 8 + dj);
-            if ((ds.draw_palette[col] & 0x10) == 0)
+            if ((ds.draw_palette[col] & 0xf0) == 0)
             {
                 uint32_t color_bits = (ds.draw_palette[col] & 0xf) << 16;
                 set_pixel(x + i, y + j, color_bits);
@@ -993,7 +993,7 @@ void vm::api_sspr(int16_t sx, int16_t sy, int16_t sw, int16_t sh,
         int16_t y = sy + sh * dj / dh;
 
         uint8_t col = m_ram.gfx.safe_get(x, y);
-        if ((ds.draw_palette[col] & 0x10) == 0)
+        if ((ds.draw_palette[col] & 0xf0) == 0)
         {
             uint32_t color_bits = (ds.draw_palette[col] & 0xf) << 16;
             set_pixel(dx + i, dy + j, color_bits);


### PR DESCRIPTION
Pico-8 seems to only care that the transparency nibble in the draw palette is non-zero, but before this fix zepto8 was checking that it was exactly 1. I don't see this difference explicitly spelled out in the official docs, but the wiki does say "non-zero" (https://pico-8.fandom.com/wiki/Memory#Draw_state).

This seems to only affect carts that are `poke`ing the draw state. One example that is fixed is [Dank Tomb](https://www.lexaloffle.com/bbs/cposts/da/dank_tomb-0.p8.png), where the green background of the character sprite was visible in zepto8, but is not after this fix.