### PR TITLE
Fix tline wrapping when out of map bounds

### DIFF
--- a/src/pico8/gfx.cpp
+++ b/src/pico8/gfx.cpp
@@ -611,9 +611,9 @@ void vm::api_tline(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
     for (;;)
     {
         // Find sprite in map memory
-        int sx = (ds.tline.offset.x + int(mx)) & 0x7f;
-        int sy = (ds.tline.offset.y + int(my)) & 0x3f;
-        uint8_t sprite = m_ram.map[128 * sy + sx];
+        int sx = (ds.tline.offset.x + int(mx));
+        int sy = (ds.tline.offset.y + int(my));
+        uint8_t sprite = api_mget(sx, sy);
         uint8_t bits = m_ram.gfx_flags[sprite];
 
         // If found, draw pixel


### PR DESCRIPTION
Using a bitwise and on the map coordinates in tline makes the sample location wrap around if it should be out of bounds. Pico 8 appears to use sprite 0 if given out of bounds map coordinates in tline, so I've changed this to just use mget. You can see the error on BoneVolt's Sonic game (https://www.lexaloffle.com/bbs/?pid=81589), where before this fix a few garbage pixels are drawn above Sonic's head, but after the fix it looks correct.