### PR TITLE
Normalize PICO-8 palette aliases and fix bitplane mask

### DIFF
--- a/src/pico8/gfx.cpp
+++ b/src/pico8/gfx.cpp
@@ -105,8 +105,8 @@ void vm::set_pixel(int16_t x, int16_t y, uint32_t color_bits)
     if (hw.bit_mask)
     {
         uint8_t old = get_current_screen().get(x, y);
-        color = (old & ~(hw.bit_mask & 7))
-              | (color & (hw.bit_mask & 7) & (hw.bit_mask >> 4));
+        color = (old & ~(hw.bit_mask & 0xf))
+              | (color & (hw.bit_mask & 0xf) & (hw.bit_mask >> 4));
     }
 
     get_current_screen().set(x, y, color);
@@ -1595,4 +1595,3 @@ void vm::api_sspr(int16_t sx, int16_t sy, int16_t sw, int16_t sh,
 }
 
 } // namespace z8::pico8
-

--- a/src/pico8/render.cpp
+++ b/src/pico8/render.cpp
@@ -22,6 +22,13 @@
 namespace z8::pico8
 {
 
+static uint8_t normalize_palette_color(uint8_t color)
+{
+    // PICO-8 masks palette entries so aliases like 16..31 and
+    // 240..255 resolve to the documented base/secret colors.
+    return color & 0x8f;
+}
+
 void vm::private_end_render()
 {
     if (m_in_pause) return;
@@ -103,7 +110,7 @@ uint8_t vm::pixel(int x, int y, u4mat2<128, 128> const& screen) const
     {
         // Raster mode: alternate palette
         if (hw_state.raster.bits[y])
-            return hw_state.raster.palette[c];
+            return normalize_palette_color(hw_state.raster.palette[c]);
     }
     else if ((hw_state.raster.mode & 0x30) == 0x30)
     {
@@ -111,12 +118,12 @@ uint8_t vm::pixel(int x, int y, u4mat2<128, 128> const& screen) const
         if ((hw_state.raster.mode & 0x0f) == c)
         {
             int c2 = (y / 8 + (hw_state.raster.bits[y] ? 1 : 0)) % 16;
-            return hw_state.raster.palette[c2];
+            return normalize_palette_color(hw_state.raster.palette[c2]);
         }
     }
 
     // Apply screen palette
-    return draw_state.screen_palette[c];
+    return normalize_palette_color(draw_state.screen_palette[c]);
 }
 
 int vm::get_ansi_color(uint8_t c) const
@@ -142,8 +149,7 @@ int vm::get_ansi_color(uint8_t c) const
     };
 
     // FIXME: support the extended palette!
-    return ansi_palette[m_front_draw_state.screen_palette[c & 0xf] & 0xf];
+    return ansi_palette[normalize_palette_color(m_front_draw_state.screen_palette[c & 0xf]) & 0xf];
 }
 
 } // namespace z8::pico8
-


### PR DESCRIPTION
PICO-8 masks screen palette entries before resolving the final display color, which means values such as 16..31 map back to the base palette and 240..255 map to the hidden palette.

Apply the same normalization to screen and raster palette entries at render time so the canonical hidden range and its byte aliases resolve consistently.

Additionally, fix bug assuming that bitplane mask is 3 bits instead of 4.